### PR TITLE
Fixed build errors for VS2015+

### DIFF
--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -45,7 +45,9 @@
 
 #define SHUT_RDWR SD_BOTH
 typedef int socklen_t;
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #define strdup _strdup
 #define stricmp _stricmp
 #define strdup _strdup


### PR DESCRIPTION
Since, snprintf() is now officially supported. We should never #define it.
Doing it will overshadow new snprintf() function defined in stdio.h.

To restrict that, this is added in stdio.h:
#ifdef snprintf
#error: Macro definition of snprintf conflicts with Standard Library function declaration”
#endif
Hence, the code doesn't compile.